### PR TITLE
Adopt the vs2017-win2016 VM image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/vsts/pipelines/languages/dotnet-core
 
 pool:
-  vmImage: Ubuntu 16.04
+  vmImage: vs2017-win2016
 
 variables:
   BuildConfiguration: Release


### PR DESCRIPTION
This change enables Code Coverage support in the build. Since Coverlet isn't used here, Windows has to be used.